### PR TITLE
Removes staff round up mailing list

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting_setup.md
+++ b/.github/ISSUE_TEMPLATE/meeting_setup.md
@@ -43,9 +43,6 @@ to maximise the notification period and increase attendance but reminders can be
       Calendar links.
 + [ ] **University Website - What's On** : Submit [a form]( https://www.sheffield.ac.uk/whatson/submit ) with details of
       the event to announce on the University's What's on public page. This should be done at least two weeks in advance.
-+ [ ] **Staff Roundup** : Submit [a form](
-      https://docs.google.com/forms/d/e/1FAIpQLSdmgw3vSjOiLXYbJ9vwnm47RFm_bjlIfmxMVnVD7YQ57SEQbA/viewform) to announce
-      the event on the staff round-up.
 + [ ] **NHS-R Slack** : If you are a member you can announce the event on the [NHS-R
       Slack](https://nhsrcommunity.slack.com/).
 + [ ] **Sheffield Digital Slack** : If you are a member you can announce the event on the [Sheffield Digital


### PR DESCRIPTION
I went to complete this today for the 2024-03-21 event and the page states that if the event is open to the public, which SheffieldR meetings are, then What's On should be used for listing. We can therefore remove this as a mailing list to notify of events.